### PR TITLE
Fix semantics for subtypes

### DIFF
--- a/out/builtins.py
+++ b/out/builtins.py
@@ -332,7 +332,7 @@ class int:
         if isinstance(self, int):
             if isinstance(other, int):
                 if py_int_to_host(self) >= py_int_to_host(0):
-                    return py_int_from_host(py_int_to_host(self) << py_int_to_host(other))
+                    return py_int_from_host(py_int_to_host(other) << py_int_to_host(self))
                 else:
                     raise ValueError("negative shift count")
             else:
@@ -368,7 +368,7 @@ class int:
         if isinstance(self, int):
             if isinstance(other, int):
                 if py_int_to_host(self) >= py_int_to_host(0):
-                    return py_int_from_host(py_int_to_host(self) >> py_int_to_host(other))
+                    return py_int_from_host(py_int_to_host(other) >> py_int_to_host(self))
                 else:
                     raise ValueError("negative shift count")
             else:

--- a/out/semantics.py
+++ b/out/semantics.py
@@ -4,352 +4,521 @@ from __compiler_intrinsics__ import define_semantics, class_getattr, py_bool_to_
 @define_semantics
 def add(x, y):
     def normal():
-        magic_method = class_getattr(x, "__add__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__radd__")
-        if magic_method is absent:
-            return raise_binary_TypeError("+", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__add__")
+    y_method = class_getattr(y, "__radd__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("+", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("+", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("+", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def bitand(x, y):
     def normal():
-        magic_method = class_getattr(x, "__and__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rand__")
-        if magic_method is absent:
-            return raise_binary_TypeError("&", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__and__")
+    y_method = class_getattr(y, "__rand__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("&", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("&", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("&", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def bitor(x, y):
     def normal():
-        magic_method = class_getattr(x, "__or__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__ror__")
-        if magic_method is absent:
-            return raise_binary_TypeError("|", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__or__")
+    y_method = class_getattr(y, "__ror__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("|", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("|", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("|", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def floordiv(x, y):
     def normal():
-        magic_method = class_getattr(x, "__floordiv__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rfloordiv__")
-        if magic_method is absent:
-            return raise_binary_TypeError("//", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__floordiv__")
+    y_method = class_getattr(y, "__rfloordiv__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("//", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("//", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("//", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def lshift(x, y):
     def normal():
-        magic_method = class_getattr(x, "__lshift__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rlshift__")
-        if magic_method is absent:
-            return raise_binary_TypeError("<<", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__lshift__")
+    y_method = class_getattr(y, "__rlshift__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("<<", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("<<", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("<<", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def matmul(x, y):
     def normal():
-        magic_method = class_getattr(x, "__matmul__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rmatmul__")
-        if magic_method is absent:
-            return raise_binary_TypeError("@", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__matmul__")
+    y_method = class_getattr(y, "__rmatmul__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("@", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("@", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("@", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def mod(x, y):
     def normal():
-        magic_method = class_getattr(x, "__mod__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rmod__")
-        if magic_method is absent:
-            return raise_binary_TypeError("%", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__mod__")
+    y_method = class_getattr(y, "__rmod__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("%", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("%", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("%", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def mul(x, y):
     def normal():
-        magic_method = class_getattr(x, "__mul__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rmul__")
-        if magic_method is absent:
-            return raise_binary_TypeError("*", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__mul__")
+    y_method = class_getattr(y, "__rmul__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("*", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("*", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("*", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def pow(x, y):
     def normal():
-        magic_method = class_getattr(x, "__pow__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rpow__")
-        if magic_method is absent:
-            return raise_binary_TypeError("**", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__pow__")
+    y_method = class_getattr(y, "__rpow__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("**", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("**", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("**", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def rshift(x, y):
     def normal():
-        magic_method = class_getattr(x, "__rshift__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rrshift__")
-        if magic_method is absent:
-            return raise_binary_TypeError(">>", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__rshift__")
+    y_method = class_getattr(y, "__rrshift__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError(">>", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError(">>", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError(">>", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def sub(x, y):
     def normal():
-        magic_method = class_getattr(x, "__sub__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rsub__")
-        if magic_method is absent:
-            return raise_binary_TypeError("-", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__sub__")
+    y_method = class_getattr(y, "__rsub__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("-", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("-", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("-", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def truediv(x, y):
     def normal():
-        magic_method = class_getattr(x, "__truediv__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rtruediv__")
-        if magic_method is absent:
-            return raise_binary_TypeError("/", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__truediv__")
+    y_method = class_getattr(y, "__rtruediv__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("/", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("/", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("/", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics
 def xor(x, y):
     def normal():
-        magic_method = class_getattr(x, "__xor__")
-        if magic_method is absent:
-            return reflected()
+        if x_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(x, y)
-            if result is NotImplemented:
-                return reflected()
-            else:
-                return result
+            return x_method(x, y)
 
     def reflected():
-        magic_method = class_getattr(y, "__rxor__")
-        if magic_method is absent:
-            return raise_binary_TypeError("^", x, y)
+        if y_method is absent:
+            return NotImplemented
         else:
-            result = magic_method(y, x)
+            return y_method(y, x)
+
+    x_type = type(x)
+    y_type = type(y)
+
+    x_method = class_getattr(x, "__xor__")
+    y_method = class_getattr(y, "__rxor__")
+
+    if x_type is y_type:
+        result = normal()
+        if result is NotImplemented:
+            return raise_binary_TypeError("^", x, y)
+    elif issubclass(x_type, y_type) and x_method is not y_method:
+        result = reflected()
+        if result is NotImplemented:
+            result = normal()
             if result is NotImplemented:
                 return raise_binary_TypeError("^", x, y)
-            else:
-                return result
+    else:
+        result = normal()
+        if result is NotImplemented:
+            result = reflected()
+            if result is NotImplemented:
+                return raise_binary_TypeError("^", x, y)
 
-    return normal()
+    return result
 
 # Auto-generated
 @define_semantics

--- a/out/semantics.py
+++ b/out/semantics.py
@@ -1,4 +1,4 @@
-from __compiler_intrinsics__ import define_semantics, class_getattr, py_bool_to_host_bool, absent, sint, bint
+from __compiler_intrinsics__ import define_semantics, class_getattr, mro_lookup, py_bool_to_host_bool, absent, sint, bint
 
 # Auto-generated
 @define_semantics
@@ -18,8 +18,8 @@ def add(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__add__")
-    y_method = class_getattr(y, "__radd__")
+    x_method = mro_lookup(x_type, "__add__")
+    y_method = mro_lookup(y_type, "__radd__")
 
     if x_type is y_type:
         result = normal()
@@ -58,8 +58,8 @@ def bitand(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__and__")
-    y_method = class_getattr(y, "__rand__")
+    x_method = mro_lookup(x_type, "__and__")
+    y_method = mro_lookup(y_type, "__rand__")
 
     if x_type is y_type:
         result = normal()
@@ -98,8 +98,8 @@ def bitor(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__or__")
-    y_method = class_getattr(y, "__ror__")
+    x_method = mro_lookup(x_type, "__or__")
+    y_method = mro_lookup(y_type, "__ror__")
 
     if x_type is y_type:
         result = normal()
@@ -138,8 +138,8 @@ def floordiv(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__floordiv__")
-    y_method = class_getattr(y, "__rfloordiv__")
+    x_method = mro_lookup(x_type, "__floordiv__")
+    y_method = mro_lookup(y_type, "__rfloordiv__")
 
     if x_type is y_type:
         result = normal()
@@ -178,8 +178,8 @@ def lshift(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__lshift__")
-    y_method = class_getattr(y, "__rlshift__")
+    x_method = mro_lookup(x_type, "__lshift__")
+    y_method = mro_lookup(y_type, "__rlshift__")
 
     if x_type is y_type:
         result = normal()
@@ -218,8 +218,8 @@ def matmul(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__matmul__")
-    y_method = class_getattr(y, "__rmatmul__")
+    x_method = mro_lookup(x_type, "__matmul__")
+    y_method = mro_lookup(y_type, "__rmatmul__")
 
     if x_type is y_type:
         result = normal()
@@ -258,8 +258,8 @@ def mod(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__mod__")
-    y_method = class_getattr(y, "__rmod__")
+    x_method = mro_lookup(x_type, "__mod__")
+    y_method = mro_lookup(y_type, "__rmod__")
 
     if x_type is y_type:
         result = normal()
@@ -298,8 +298,8 @@ def mul(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__mul__")
-    y_method = class_getattr(y, "__rmul__")
+    x_method = mro_lookup(x_type, "__mul__")
+    y_method = mro_lookup(y_type, "__rmul__")
 
     if x_type is y_type:
         result = normal()
@@ -338,8 +338,8 @@ def pow(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__pow__")
-    y_method = class_getattr(y, "__rpow__")
+    x_method = mro_lookup(x_type, "__pow__")
+    y_method = mro_lookup(y_type, "__rpow__")
 
     if x_type is y_type:
         result = normal()
@@ -378,8 +378,8 @@ def rshift(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__rshift__")
-    y_method = class_getattr(y, "__rrshift__")
+    x_method = mro_lookup(x_type, "__rshift__")
+    y_method = mro_lookup(y_type, "__rrshift__")
 
     if x_type is y_type:
         result = normal()
@@ -418,8 +418,8 @@ def sub(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__sub__")
-    y_method = class_getattr(y, "__rsub__")
+    x_method = mro_lookup(x_type, "__sub__")
+    y_method = mro_lookup(y_type, "__rsub__")
 
     if x_type is y_type:
         result = normal()
@@ -458,8 +458,8 @@ def truediv(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__truediv__")
-    y_method = class_getattr(y, "__rtruediv__")
+    x_method = mro_lookup(x_type, "__truediv__")
+    y_method = mro_lookup(y_type, "__rtruediv__")
 
     if x_type is y_type:
         result = normal()
@@ -498,8 +498,8 @@ def xor(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__xor__")
-    y_method = class_getattr(y, "__rxor__")
+    x_method = mro_lookup(x_type, "__xor__")
+    y_method = mro_lookup(y_type, "__rxor__")
 
     if x_type is y_type:
         result = normal()

--- a/semPy/code_generation/templates.py
+++ b/semPy/code_generation/templates.py
@@ -5,7 +5,7 @@
 # ======================================================================================================================
 
 semantics_template = \
-    """from __compiler_intrinsics__ import define_semantics, class_getattr, py_bool_to_host_bool, absent, sint, bint
+    """from __compiler_intrinsics__ import define_semantics, class_getattr, mro_lookup, py_bool_to_host_bool, absent, sint, bint
 
 {arithmetic}
 
@@ -270,8 +270,8 @@ def {op}(x, y):
     x_type = type(x)
     y_type = type(y)
 
-    x_method = class_getattr(x, "__{magic_method}__")
-    y_method = class_getattr(y, "__r{magic_method}__")
+    x_method = mro_lookup(x_type, "__{magic_method}__")
+    y_method = mro_lookup(y_type, "__r{magic_method}__")
 
     if x_type is y_type:
         result = normal()

--- a/semPy/compute_behaviors.py
+++ b/semPy/compute_behaviors.py
@@ -1630,6 +1630,9 @@ def partial_eval_is(left, right, rte):
         if isinstance(left.origin, ast.Constant) and isinstance(right.origin, ast.Constant):
             return ast.Constant(left.value.value is right.value.value)
 
+    if isinstance(left, PPYFunction) and isinstance(right, PPYFunction):
+        return ast.Constant(left.origin is right.origin)
+
     # Unresolved
     return None
 

--- a/semPy/compute_behaviors.py
+++ b/semPy/compute_behaviors.py
@@ -824,6 +824,7 @@ ppy_intrinsic_absent = PPYIntrinsic("absent")
 ppy_intrinsic_sint = PPYIntrinsic("sint")
 ppy_intrinsic_bint = PPYIntrinsic("bint")
 ppy_intrinsic_class_getattr = PPYIntrinsic("class_getattr")
+ppy_intrinsic_mro_lookup = PPYIntrinsic("mro_lookup")
 ppy_intrinsic_define_semantics = PPYIntrinsic("define_semantics")
 ppy_intrinsic_builtin = PPYIntrinsic("builtin")
 ppy_intrinsic_private = PPYIntrinsic("private")
@@ -960,6 +961,8 @@ def simplify_intrinsic_call(fn, args, keywords, rte):
 def partial_eval_intrinsic_call(fn, args, keywords, rte, return_kind=ReturnKind.as_return()):
     if fn is ppy_intrinsic_class_getattr:
         yield return_kind.do_return(intrinsic_eval_class_getattr_call(args, rte))
+    elif fn is ppy_intrinsic_mro_lookup:
+        yield return_kind.do_return(intrinsic_eval_mro_lookup_call(args, rte))
     elif isinstance(fn, PPYIntrinsic):
         # Cannot evaluate but can simplify
         value = simplify_intrinsic_call(fn, args, keywords, rte)
@@ -979,26 +982,38 @@ def intrinsic_eval_class_getattr_call(args, rte):
 
     if isinstance(obj, PPYValue):
         if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
-            type_ = rte.modules["builtins"]["int"] if obj.type in (ppy_intrinsic_sint, ppy_intrinsic_bint) else obj.type
+            type_ = obj.type
 
             if type_ is None:
                 raise NotImplementedError(f"partial_eval_class_getattr_call: could not resolve type")
-            else:
-                attr_name = attr.value
 
-                for ppy_class in type_.mro:
-                    attr = ppy_class.get(attr_name)
-
-                    if attr is not None:
-                        return attr
-
-                return ppy_intrinsic_absent
-        else:
-            raise ValueError("partial_eval_class_getattr_call: second argument must be a string literal")
+            return intrinsic_eval_mro_lookup_call([type_, attr], rte)
     else:
         raise NotImplementedError(
             "partial_eval_class_getattr_call: first argument must have been resolved to a ppy object")
 
+
+def intrinsic_eval_mro_lookup_call(args, rte):
+    type_ = args[0]
+    attr = args[1]
+
+    type_ = rte.modules["builtins"]["int"] if type_ in (ppy_intrinsic_sint, ppy_intrinsic_bint) else type_
+
+    if not isinstance(type_, PPYClass):
+        raise TypeError('intrinsic_eval_mro_lookup_call: first argument is not a type')
+
+    if not isinstance(attr, ast.Constant) or not isinstance(attr.value, str):
+        raise TypeError("intrinsic_eval_mro_lookup_call: second argument must be a string literal")
+
+    attr_name = attr.value
+
+    for ppy_class in type_.mro:
+        attr = ppy_class.get(attr_name)
+
+        if attr is not None:
+            return attr
+
+    return ppy_intrinsic_absent
 
 # End of intrinsic calls
 


### PR DESCRIPTION
The arithmetic semantics is missing a check when the rhs operand is of the same type or of a supertype of the lhs operand. This was pointed by Guido Van Rossum here: https://github.com/faster-cpython/ideas/issues/626

This PR adds the missing checks. It required minimal updates to the partial evaluator, mainly to remove some dead code that was generated in the behaviors.

The behaviors were regenerated from the fixed semantics. Notice that they are identical to the previous ones.